### PR TITLE
fix: protect concurrent map access with mutexLock

### DIFF
--- a/traceloop-sdk/prompt_registry.go
+++ b/traceloop-sdk/prompt_registry.go
@@ -31,9 +31,11 @@ func (instance *Traceloop) populatePromptRegistry() {
 		return
 	}
 
+	instance.registryMutex.Lock()
 	for _, prompt := range response.Prompts {
 		instance.promptRegistry[prompt.Key] = &prompt
 	}
+	instance.registryMutex.Unlock()
 }
 
 func (instance *Traceloop) pollPrompts() {
@@ -55,6 +57,8 @@ func (instance *Traceloop) pollPrompts() {
 }
 
 func (instance *Traceloop) getPromptVersion(key string) (*model.PromptVersion, error) {
+	instance.registryMutex.RLock()
+	defer instance.registryMutex.RUnlock()
 	if instance.promptRegistry[key] == nil {
 		return nil, fmt.Errorf("prompt with key %s not found", key)
 	}

--- a/traceloop-sdk/sdk.go
+++ b/traceloop-sdk/sdk.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -21,6 +22,7 @@ const PromptsPath = "/v1/traceloop/prompts"
 type Traceloop struct {
 	config         Config
 	promptRegistry model.PromptRegistry
+	registryMutex  sync.RWMutex
 	tracerProvider *trace.TracerProvider
 	http.Client
 }


### PR DESCRIPTION
## Description
This PR fixes concurrent map access issues in the promptRegistry. The race conditions occur in two main scenarios:

1. Background Polling vs Business Access
   - A background goroutine polls and updates the promptRegistry every 5 seconds (via pollPrompts)
   - Meanwhile, business logic reads the registry through GetOpenAIChatCompletionRequest
   - This creates a read/write race condition on the shared map

2. Multiple Client Requests
   - Multiple API requests can trigger GetOpenAIChatCompletionRequest simultaneously
   - Each request reads from the promptRegistry
   - While these reads occur, the background polling might update the map
   
### Changes
- Added mutex lock protection in `populatePromptRegistry()` for map writes
- Ensured proper read lock usage in `getPromptVersion()`
- Protected all concurrent map access points with sync.RWMutex