### PR TITLE
fix: disable sync if not using traceloop

### DIFF
--- a/traceloop-sdk/sdk.go
+++ b/traceloop-sdk/sdk.go
@@ -69,7 +69,7 @@ func (instance *Traceloop) initialize(ctx context.Context) error {
 
 	log.Printf("Traceloop %s SDK initialized. Connecting to %s\n", Version(), instance.config.BaseURL)
 
-	if strings.HasSuffix(instance.config.BaseURL, "traceloop.com") {
+	if strings.HasSuffix(strings.ToLower(instance.config.BaseURL), "traceloop.com") {
 		instance.pollPrompts()
 	}
 	err := instance.initTracer(ctx, instance.config.ServiceName)

--- a/traceloop-sdk/sdk.go
+++ b/traceloop-sdk/sdk.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -68,7 +69,9 @@ func (instance *Traceloop) initialize(ctx context.Context) error {
 
 	log.Printf("Traceloop %s SDK initialized. Connecting to %s\n", Version(), instance.config.BaseURL)
 
-	instance.pollPrompts()
+	if strings.HasSuffix(instance.config.BaseURL, "traceloop.com") {
+		instance.pollPrompts()
+	}
 	err := instance.initTracer(ctx, instance.config.ServiceName)
 	if err != nil {
 		return err
@@ -91,7 +94,6 @@ func setMessagesAttribute(span apitrace.Span, prefix string, messages []Message)
 	}
 }
 
-
 // Tool calling attribute helpers for new types
 func setToolCallsAttribute(span apitrace.Span, messagePrefix string, toolCalls []ToolCall) {
 	for i, toolCall := range toolCalls {
@@ -104,8 +106,6 @@ func setToolCallsAttribute(span apitrace.Span, messagePrefix string, toolCalls [
 		)
 	}
 }
-
-
 
 func setToolsAttribute(span apitrace.Span, tools []Tool) {
 	if len(tools) == 0 {
@@ -131,7 +131,6 @@ func setToolsAttribute(span apitrace.Span, tools []Tool) {
 		}
 	}
 }
-
 
 func (instance *Traceloop) tracerName() string {
 	if instance.config.TracerName != "" {
@@ -184,7 +183,6 @@ func (llmSpan *LLMSpan) LogCompletion(ctx context.Context, completion Completion
 	defer llmSpan.span.End()
 	return nil
 }
-
 
 func (instance *Traceloop) Shutdown(ctx context.Context) {
 	if instance.tracerProvider != nil {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `pollPrompts()` in `initialize()` now runs only if `BaseURL` ends with `traceloop.com`, with logging for non-traceloop.com endpoints.
> 
>   - **Behavior**:
>     - `pollPrompts()` in `initialize()` now only runs if `BaseURL` ends with `traceloop.com`.
>     - Logs a message indicating when synchronization is disabled for non-traceloop.com endpoints.
>   - **Imports**:
>     - Added `strings` package to support new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fgo-openllmetry&utm_source=github&utm_medium=referral)<sup> for 09ce94f16ab17705e7d0e5733095a25c9bb2faf7. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Prompt synchronization now runs only when connected to a traceloop.com endpoint (case-insensitive match to the configured base URL).

- Documentation
  - No user-facing documentation changes required.

- Tests
  - No test-related changes mentioned.

- Chores
  - Minor import update to support the new conditional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->